### PR TITLE
fix carsCreate navigate/cars

### DIFF
--- a/client/src/Components/CarFormPage/CarsCreate.jsx
+++ b/client/src/Components/CarFormPage/CarsCreate.jsx
@@ -229,10 +229,13 @@ function onSubmit(e) {
     draggable: true,
     progress: undefined,
     theme: "colored",   
-    onClose: () => {
-      navigate("/cars");
-    }
+    // onClose: () => {
+    //   navigate("/cars");
+    // }    
     })
+    setTimeout(function() {
+      navigate("/cars");      
+    }, 3000);
   }
 
 const [imageSelected, setImageSelected] = useState("")

--- a/client/src/Components/Cars/Cars.jsx
+++ b/client/src/Components/Cars/Cars.jsx
@@ -104,12 +104,14 @@ export default function Cars() {
                         );
                     })
                 ) :
-                    <div className={style.cardModal}>
-                       <h1>nada</h1>
+
+                handleAlert()
+                    // <div className={style.cardModal}>
+                    //    <h1>nada</h1>
 
 
 
-                    </div>
+                    // </div>
                 }
             </div>)}
             </div>

--- a/client/src/Components/Filters/Filters.jsx
+++ b/client/src/Components/Filters/Filters.jsx
@@ -19,7 +19,10 @@ const [filterYear, setFilterYear] = useState("");
         }
       }
     }
-
+    arr.sort(function(a, b) {
+        return b - a;
+      });
+      
     useEffect(() => {
         dispatch(getCars());
         dispatch(cleanState());


### PR DESCRIPTION
No funciona al menos en localhost el onClose dentro del toast.succes. Capaz que funciona en el deploy (segun google) asi que lo deje comentado. Hay que corroborarlo.
Como no funciona le puse un setTimeout como fix temporal. Sino se iba directo a /cars sin que se vea la alerta.

Los filtros estan andando joya. Los corrobore uno por uno, combinados 1 por 1.
Cambie solo la alertas en vez de que diga "nada".... ahora saltan como antes.
Acomode el array de years para que este ordenado.